### PR TITLE
Fix: 리액트쿼리 오류 세팅 및 상대 경로 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,7 @@
-import {
-  QueryClientProvider,
-  QueryErrorResetBoundary,
-  useQueryErrorResetBoundary,
-} from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { queryClient } from "./services/TanstackQueryStore";
 import CommonLayout from "./layouts/CommonLayout";
-import { ErrorBoundary } from "react-error-boundary";
 import NotFound from "./pages/NotFound";
 import Tmp from "./pages/Tmp";
 import Home from "./pages/Home";
@@ -17,6 +12,7 @@ import ClubDetail from "./pages/club/ClubDetail";
 import Recruitment from "./pages/recruitment/Recruitment";
 import Favorite from "./pages/Favorite";
 import Login from "./pages/Login";
+import QueryErrorBoundary from "./services/QueryErrorBoundary";
 
 const router = createBrowserRouter([
   {
@@ -53,25 +49,14 @@ const router = createBrowserRouter([
 ]);
 
 function App() {
-  const { reset } = useQueryErrorResetBoundary();
   return (
     <QueryClientProvider client={queryClient}>
-      <QueryErrorResetBoundary>
-        <ErrorBoundary
-          onReset={reset}
-          fallbackRender={({ resetErrorBoundary }) => (
-            <div>
-              There was an error!
-              <button onClick={() => resetErrorBoundary()}>Try again</button>
-            </div>
-          )}
-        >
-          <Suspense fallback={<Loading />}>
-            <Login />
-            <RouterProvider router={router} />
-          </Suspense>
-        </ErrorBoundary>
-      </QueryErrorResetBoundary>
+      <QueryErrorBoundary>
+        <Suspense fallback={<Loading />}>
+          <Login />
+          <RouterProvider router={router} />
+        </Suspense>
+      </QueryErrorBoundary>
     </QueryClientProvider>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,6 @@ import ClubDetail from "./pages/club/ClubDetail";
 import Recruitment from "./pages/recruitment/Recruitment";
 import Favorite from "./pages/Favorite";
 import Login from "./pages/Login";
-import QueryErrorBoundary from "./services/QueryErrorBoundary";
 
 const router = createBrowserRouter([
   {
@@ -34,7 +33,9 @@ const router = createBrowserRouter([
       },
       {
         path: "clubs/:id",
-        element: <ClubDetail />,
+        element: (
+            <ClubDetail />
+        ),
       },
       {
         path: "recruit",
@@ -51,12 +52,10 @@ const router = createBrowserRouter([
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <QueryErrorBoundary>
-        <Suspense fallback={<Loading />}>
-          <Login />
-          <RouterProvider router={router} />
-        </Suspense>
-      </QueryErrorBoundary>
+      <Suspense fallback={<Loading />}>
+        <Login />
+        <RouterProvider router={router} />
+      </Suspense>
     </QueryClientProvider>
   );
 }

--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosResponse } from "axios";
-import { userInterface } from "../types/userInfoType";
+import { userInterface } from "@/types/userInfoType";
 
 interface AuthResponse {
   accessToken: string;

--- a/src/api/clubs.api.ts
+++ b/src/api/clubs.api.ts
@@ -10,5 +10,5 @@ export const getClubItemsDetail = async (
   id: string
 ): Promise<ClubDetailResponseType> => {
   const { data } = await api.get(`/clubs/${id}`);
-  return data;
+  throw new Error("!!");
 };

--- a/src/api/clubs.api.ts
+++ b/src/api/clubs.api.ts
@@ -1,5 +1,5 @@
 import api from ".";
-import { ClubDetailResponseType, ClubResponseType } from "../types/clubType";
+import { ClubDetailResponseType, ClubResponseType } from "@/types/clubType";
 
 export const getClubItems = async (): Promise<ClubResponseType> => {
   const { data } = await api.get("/clubs");
@@ -10,5 +10,5 @@ export const getClubItemsDetail = async (
   id: string
 ): Promise<ClubDetailResponseType> => {
   const { data } = await api.get(`/clubs/${id}`);
-  throw new Error("!!");
+  return data;
 };

--- a/src/hooks/queries/clubs.query.ts
+++ b/src/hooks/queries/clubs.query.ts
@@ -1,6 +1,6 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { getClubItems, getClubItemsDetail } from "../../api/clubs.api";
-import { ClubDetailResponseType, ClubResponseType } from "../../types/clubType";
+import { getClubItems, getClubItemsDetail } from "@/api/clubs.api";
+import { ClubDetailResponseType, ClubResponseType } from "@/types/clubType";
 
 export const useGetClubs = () => {
   return useSuspenseQuery<ClubResponseType>({

--- a/src/layouts/CommonLayout.tsx
+++ b/src/layouts/CommonLayout.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import Footer from "./components/Footer";
 import Header from "./components/Header";
 import SideBar from "./sidebar/SideBar";
+import QueryErrorBoundary from "@/services/QueryErrorBoundary";
 
 const Background = styled.div`
   width: 100%;
@@ -12,15 +13,14 @@ const Background = styled.div`
 `;
 
 const MainContents = styled.div`
-  padding-top: 1%;
-  width: 88%;
-  position: relative;
+  padding: 1%;
+  width: auto;
 `;
 
 const MainContentsSection = styled.div`
   display: flex;
   flex-direction: row;
-  min-height: 85vh;
+  min-height: 84vh;
   width: 100%;
   box-sizing: border-box;
   background-color: #f9fafb;
@@ -33,7 +33,9 @@ function CommonLayout() {
       <MainContentsSection>
         <SideBar />
         <MainContents>
-          <Outlet />
+          <QueryErrorBoundary>
+            <Outlet />
+          </QueryErrorBoundary>
         </MainContents>
       </MainContentsSection>
       <Footer />

--- a/src/layouts/components/Header.tsx
+++ b/src/layouts/components/Header.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import DummyLogo from "@/assets/react.svg?react";
-import { useLoginModalStore } from "../../stores/useLoginModalStore";
+import { useLoginModalStore } from "@/stores/useLoginModalStore";
 
 const HeaderContainer = styled.div`
   height: 60px;

--- a/src/layouts/sidebar/components/SideBarContentList.tsx
+++ b/src/layouts/sidebar/components/SideBarContentList.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { clubItems } from "../const/pathLinks";
-import Spacing from "../../../components/Spacing";
+import Spacing from "@/components/Spacing";
 
 const SectionTitle = styled(Link)`
   width: 90%;

--- a/src/mocks/handlers/recruit.ts
+++ b/src/mocks/handlers/recruit.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from "msw";
-import { ClubType } from "../../types/clubType";
+import { ClubType } from "@/types/clubType";
 
 export const recruitDummyData: ClubType[] = [
   {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,9 +1,9 @@
-import { useLoginModalStore } from "../stores/useLoginModalStore";
+import { useLoginModalStore } from "@/stores/useLoginModalStore";
 import { useState } from "react";
 import { createPortal } from "react-dom";
 import styled from "styled-components";
-import { saveAuthTokens } from "../api/auth.api";
-import { userInterface } from "../types/userInfoType";
+import { saveAuthTokens } from "@/api/auth.api";
+import { userInterface } from "@/types/userInfoType";
 
 const ModalWrapper = styled.div<{ open: boolean }>`
   display: ${({ open }) => (open ? "flex" : "none")};

--- a/src/pages/club/ClubBox.tsx
+++ b/src/pages/club/ClubBox.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import DefaultImage from "@/assets/react.svg?react";
-import { ClubType } from "../../types/clubType";
+import { ClubType } from "@/types/clubType";
 import StartLogo from "@/assets/starLogo.svg?react";
 import StartEmptyLogo from "@/assets/starEmptyLogo.svg?react";
 

--- a/src/pages/club/ClubDetail.tsx
+++ b/src/pages/club/ClubDetail.tsx
@@ -1,7 +1,7 @@
 //동아리 상세 페이지
 import styled from "styled-components";
-import { useGetClubsDetail } from "../../hooks/queries/clubs.query";
-import useCustomParams from "../../hooks/useCustomParams";
+import { useGetClubsDetail } from "@/hooks/queries/clubs.query";
+import useCustomParams from "@/hooks/useCustomParams";
 
 //전체 레이아웃
 const Container = styled.div`

--- a/src/pages/club/ClubList.tsx
+++ b/src/pages/club/ClubList.tsx
@@ -1,8 +1,8 @@
-import ClubBox from "../../pages/club/ClubBox";
+import ClubBox from "@/pages/club/ClubBox";
 import styled from "styled-components";
 import Pagination from "../recruitment/components/Pagination";
-import { ClubType } from "../../types/clubType";
-import { useGetClubs } from "../../hooks/queries/clubs.query";
+import { ClubType } from "@/types/clubType";
+import { useGetClubs } from "@/hooks/queries/clubs.query";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/src/pages/recruitment/Recruitment.tsx
+++ b/src/pages/recruitment/Recruitment.tsx
@@ -3,7 +3,7 @@ import ClubCard from "./components/ClubCard";
 import styled from "styled-components";
 import SortOption from "./components/SortOption";
 import PaginationComponent from "./components/Pagination";
-import { ClubType } from "../../types/clubType";
+import { ClubType } from "@/types/clubType";
 
 const ITEMS_PER_PAGE = 9; // 페이지당 게시물 수
 

--- a/src/pages/recruitment/components/ClubCard.tsx
+++ b/src/pages/recruitment/components/ClubCard.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { ClubType } from "../../../types/clubType";
+import { ClubType } from "@/types/clubType";
 
 const Card = styled.div`
   width: 100%;

--- a/src/services/QueryErrorBoundary.tsx
+++ b/src/services/QueryErrorBoundary.tsx
@@ -1,0 +1,26 @@
+import { useQueryErrorResetBoundary } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import {ErrorBoundary} from "react-error-boundary";
+
+export default function QueryErrorBoundary({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const { reset } = useQueryErrorResetBoundary();
+
+  return (
+    <ErrorBoundary
+      onReset={reset}
+      fallbackRender={({ error, resetErrorBoundary }) => (
+        <div style={{ textAlign: "center" }}>
+          <h2>⚠️ 오류 발생!</h2>
+          <p>{error.message}</p>
+          <button onClick={resetErrorBoundary}>다시 시도</button>
+        </div>
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/src/services/TanstackQueryStore.ts
+++ b/src/services/TanstackQueryStore.ts
@@ -5,7 +5,7 @@ export const queryClient = new QueryClient({
     queries: {
       staleTime: 5000,
       gcTime: 300000,
-      notifyOnChangeProps: "all",
+      throwOnError: true,
     },
   },
 });

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -22,19 +22,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "baseUrl": "./",
-  "paths": {
-    "@/*": ["src/*"],
-    "@assets/*": ["src/assets/*"],
-    "@components/*": ["src/components/*"],
-    "@constant/*": ["src/constant/*"],
-    "@hooks/*": ["src/hooks/*"],
-    "@pages/*": ["src/pages/*"],
-    "@services/*": ["src/services/*"],
-    "@store/*": ["src/store/*"],
-    "@utils/*": ["src/utils/*"],
-    "@types/*": ["src/types/*"],
-    "@api/*": ["src/api/*"]
-  },
+  "extends": "./tsconfig.json",
   "include": ["src", "vite.config.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       "@store/*": ["src/store/*"],
       "@utils/*": ["src/utils/*"],
       "@types/*": ["src/types/*"],
-      "@api/*": ["src/api/*"]
+      "@api/*": ["src/api/*"],
+      "@const/*": ["src/const*"]
     }
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

Fix: 리액트쿼리 오류 세팅 및 상대 경로 수정

## 📝작업 내용

1. 리액트 쿼리 오류 발생시 오류 원인 뜨게 설정했어요
2. 상대경로 @가 잘 적용이 안되서 수정했어요

### 스크린샷 (선택)

![스크린샷 2025-02-19 185230](https://github.com/user-attachments/assets/6a634ec9-6f61-4f26-b626-175f43e8b763)



## 💬리뷰 요구사항(선택)

import { userInterface } from "@/types/userInfoType";
이런식으로 다시 정상화됬습니다.(궁금하면 아래 참고)
https://be-senior-developer.tistory.com/252

리액트 쿼리 errorBoundary가 궁금하면 아래 참고
https://github.com/ssi02014/react-query-tutorial?tab=readme-ov-file#usequeryerrorresetboundary


아래 코드 이렇게 바꿔서 오류내면 잘 나오는거 확인할 수 있어요
export const getClubItemsDetail = async (
  id: string
): Promise<ClubDetailResponseType> => {
  const { data } = await api.get(`/clubs/${id}`);
  throw new Error("!!");
};

