### PR TITLE
Feat: 정렬 기능 추가

### DIFF
--- a/src/pages/recruitment/Recruitment.tsx
+++ b/src/pages/recruitment/Recruitment.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import SortOption from "./components/SortOption";
 import PaginationComponent from "./components/Pagination";
 import { ClubType } from "@/types/clubType";
+import { sortClubs } from "./utils/sortClubs";
 
 const ITEMS_PER_PAGE = 9; // 페이지당 게시물 수
 
@@ -33,9 +34,10 @@ const ClubCardWrapper = styled.div`
 
 function Recruitment() {
   const [clubs, setClubs] = useState<ClubType[]>([]);
-  const [buttonState, setButtonState] = useState<string>("최신순"); // 정렬 옵션 상태
-  const [currentPage, setCurrentPage] = useState(1); // 현재 페이지 번호
+  const [sortedClubs, setSortedClubs] = useState<ClubType[]>([]); // 정렬된 동아리 목록
   const [sliceClub, setSliceClub] = useState<ClubType[]>([]); // 현재 페이지 게시물 객체
+  const [buttonState, setButtonState] = useState<string>("마감일순"); // 정렬 옵션 상태
+  const [currentPage, setCurrentPage] = useState(1); // 현재 페이지 번호
 
   // 동아리 데이터 패칭
   useEffect(() => {
@@ -57,15 +59,21 @@ function Recruitment() {
 
     fetchClubsData();
   }, []);
+  
+  // 정렬 상태 반영
+  useEffect(() => {
+    const sorted = sortClubs(clubs, buttonState);
+    setSortedClubs(sorted);
+  }, [clubs, buttonState]);
 
   // 현재 페이지 동아리 게시물 객체
   useEffect(() => {
     const cur = (currentPage - 1) * ITEMS_PER_PAGE;
-    const currentClub = clubs.slice(cur, cur + ITEMS_PER_PAGE);
+    const currentClub = sortedClubs.slice(cur, cur + ITEMS_PER_PAGE);
     setSliceClub(currentClub);
-  }, [currentPage, clubs]);
+  }, [currentPage, sortedClubs]);
 
-  // 정렬 상태 변경경
+  // 정렬 상태 변경
   function handleSortChange(value: string) {
     setButtonState(value);
   }

--- a/src/pages/recruitment/utils/sortClubs.ts
+++ b/src/pages/recruitment/utils/sortClubs.ts
@@ -1,0 +1,30 @@
+import { ClubType } from "../../../types/clubType";
+
+// 모집 공고 정렬 함수
+export function sortClubs(clubs: ClubType[], sortBy: string): ClubType[] {
+    const sortedClubs = [...clubs];
+
+    const today = new Date().getTime(); // 마감일은 마지막으로 미루기 위한 기준
+
+    if (sortBy === "마감일순") {
+        sortedClubs.sort((a, b) => {
+            const dateA = a.recruitEndDate ? new Date(a.recruitEndDate).getTime() : 0;
+            const dateB = b.recruitEndDate ? new Date(b.recruitEndDate).getTime() : 0;
+
+            // 마감일이 지난 경우 마지막으로 밀기
+            if (dateA < today) {
+                return 1;
+            } else if (dateB < today) {
+                return -1;
+            } else return dateA - dateB;  // 마감일이 지나지 않은 경우 빠른 마감일 우선 정렬
+        });
+    } else if (sortBy === "최신순") {
+        sortedClubs.sort((a, b) => {
+            const dateA = a.recruitStartDate ? new Date(a.recruitStartDate).getTime() : 0;
+            const dateB = b.recruitStartDate ? new Date(b.recruitStartDate).getTime() : 0;
+            return dateB - dateA;
+        });
+    }   // 즐겨찾기 정렬 필요
+
+    return sortedClubs;
+}


### PR DESCRIPTION
- 마감일순 우선 표시
- 즐겨찾기 정렬 미구현

## #️⃣연관된 이슈

Feat: 정렬 기능 추가

## 📝작업 내용

- [x] 마감일순 기준 정렬 기능 추가

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/778d2f20-2fda-4a17-b040-825f70ac699e)


## 💬리뷰 요구사항(선택)

정렬 기능은 따로 utils에 빼서 만들어두었습니다.
즐겨찾기 정렬은 아직 미구현입니다.
모집 마감의 경우 우선 순위에서 제외된다고 생각하여 순서를 모집임박>모집중>모집마감 으로 정하였습니다.
clubs를 담는 객체가 3개나 되어서 과하다고 생각되기는 하는데, 각각의 역할을 가지고 있어서 합칠 수가 없었습니다. 좋은 방법이 있다면 알려주세요!