### PR TITLE
Feat: 즐겨찾기 버튼 컴포넌트 추가

### DIFF
--- a/src/pages/components/FavoriteButton.tsx
+++ b/src/pages/components/FavoriteButton.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import StartLogo from "@/assets/starLogo.svg?react";
+import StartEmptyLogo from "@/assets/starEmptyLogo.svg?react";
+import axios from "axios";
+
+interface FavoriteButtonProps {
+    clubId: number;
+    clubFavorite: boolean;
+}
+
+function FavoriteButton({ clubId, clubFavorite }: FavoriteButtonProps) {
+    // 현 즐겨찾기 상태
+    const [isFavorite, setIsFavorite] = useState(clubFavorite);
+  
+    const onClick = () => {
+      if (isFavorite) {
+        // 즐겨찾기 해제
+        axios
+          .delete(`/favorites/${clubId}`)
+          .then(() => {
+            setIsFavorite(false);
+          })
+          .catch((error) => {
+            console.error("즐겨찾기 해제 실패:", error);
+          });
+      } else {
+        // 즐겨찾기 등록
+        axios
+          .post(`/favorites/${clubId}`)
+          .then(() => {
+            setIsFavorite(true);
+          })
+          .catch((error) => {
+            console.error("즐겨찾기 등록 실패:", error);
+          });
+      }
+    };
+  
+    return (
+      <div onClick={() => onClick()} style={{ cursor: "pointer" }}>
+        {isFavorite ? <StartLogo /> : <StartEmptyLogo />}
+      </div>
+    );
+  }
+  
+  export default FavoriteButton;


### PR DESCRIPTION
## #️⃣연관된 이슈

Feat: 즐겨찾기 버튼 컴포넌트 추가

## 📝작업 내용

- [ ] 즐겨찾기 버튼 컴포넌트 분리
- [ ] 버튼 api 연결

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

즐겨찾기 버튼을 공통 컴포넌트로 (pages/components/)분리해두었습니다.
club.id와 club.favorite을 전달해주면 되게 해놓았으나 그냥 club전체를 넘겨주어도 무방할것 같긴 합니다.
등록/해제 기능은 테스트까지는 해볼 필요 없다고 생각해서 임시로 작성해두었습니다.