### PR TITLE
Fix: 사이드바 검색과 상세 필터 수정

### DIFF
--- a/src/layouts/sidebar/components/SideBarSearch.tsx
+++ b/src/layouts/sidebar/components/SideBarSearch.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import SearchLogo from "@/assets/searchLogo.svg?react";
-import FilterLogo from "@/assets/filterLogo.svg?react";
+import SideBarSearchFilter from "./SideBarSearchFilter";
 import { useState } from "react";
 
 const SearchSection = styled.div`
@@ -36,28 +36,34 @@ const SearchButton = styled.button`
   cursor: pointer;
 `;
 
-const SearchFilter = styled.button`
-  width: 90%;
-  height: 30px;
-  border: 1px solid #9ca3af;
-  border-radius: 5px;
-  background-color: white;
-  padding: 0.2%;
-  text-align: center;
-  color: #4b5563;
-  margin-bottom: 20px;
-  font-size: small;
-`;
+//setSearchText -> 검색어를 Clublist에 전달
+//setSelectedCategory -> 선택된 카테고리를 Clublist에 전달
+//localSearchText -> 사이드바 내부에서만 검색어
+//localSelectedCategory -> 사이드바 내부에서만 카테고리
 
-function SideBarSearch() {
-  const [searchText, setSearchText] = useState<string>("");
+interface SideBarSearchProps {
+  setSearchText: (text: string) => void; 
+  setSelectedCategory: (category: string) => void; 
+}
 
-  function onChange(e: React.ChangeEvent<HTMLInputElement>) {
-    setSearchText(e.target.value);
+function SideBarSearch({ setSearchText, setSelectedCategory }: SideBarSearchProps) {
+  const [localSearchText, setLocalSearchText] = useState("");
+  const [localSelectedCategory, setLocalSelectedCategory] = useState("");
+
+  function handleSearchChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const searchValue = e.target.value;
+    setLocalSearchText(searchValue);
+    setSearchText(searchValue);
   }
 
-  function onClick() {
-    setSearchText("");
+  function handleSearchClear() {
+    setLocalSearchText("");
+    setSearchText?.("");
+  }
+
+  function handleCategoryChange(category: string) {
+    setLocalSelectedCategory(category);
+    setSelectedCategory(category);
   }
 
   return (
@@ -65,17 +71,18 @@ function SideBarSearch() {
       <SearchSection>
         <SearchContainer
           placeholder="동아리 검색"
-          value={searchText}
-          onChange={onChange}
-        ></SearchContainer>
-        <SearchButton onClick={onClick}>
+          value={localSearchText}
+          onChange={handleSearchChange}
+        />
+        <SearchButton onClick={handleSearchClear}>
           <SearchLogo />
         </SearchButton>
       </SearchSection>
-      <SearchFilter>
-        <FilterLogo width={12} height={12} style={{ marginRight: 5 }} />
-        상세 필터
-      </SearchFilter>
+
+      <SideBarSearchFilter
+        selectedCategory={localSelectedCategory}
+        setSelectedCategory={handleCategoryChange}
+      />
     </>
   );
 }

--- a/src/layouts/sidebar/components/SideBarSearchFilter.tsx
+++ b/src/layouts/sidebar/components/SideBarSearchFilter.tsx
@@ -1,0 +1,82 @@
+import styled from "styled-components";
+import FilterLogo from "@/assets/filterLogo.svg?react";
+import { useState } from "react";
+
+interface SideBarSearchFilterProps {
+    selectedCategory: string;
+    setSelectedCategory: (category: string) => void;
+  }
+
+const SearchFilter = styled.button`
+  width: 90%;
+  height: 30px;
+  border: 1px solid #9ca3af;
+  border-radius: 5px;
+  background-color: white;
+  padding: 0.2%;
+  text-align: center;
+  color: #4b5563;
+  margin-bottom: 8px;
+  font-size: small;
+  cursor: pointer;
+`;
+
+const Dropdown = styled.div`
+  width: 80%;
+  background-color: white;
+  border: 1px solid #9ca3af;
+  border-radius: 5px;
+  z-index: 12;
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 5px;
+`;
+
+const DropdownItem = styled.div`
+  padding: 5px;
+  cursor: pointer;
+  &:hover {
+    background-color: #f3f4f6;
+  }
+`;
+
+const categories = [
+    "종교", 
+    "학술/교양", 
+    "봉사", 
+    "체육", 
+    "문화", 
+    "공연"];
+
+    function SideBarSearchFilter({ selectedCategory, setSelectedCategory }: SideBarSearchFilterProps) {
+        const [filterOpen, setFilterOpen] = useState(false);
+      
+        function toggleFilter() {
+          setFilterOpen(!filterOpen);
+        }
+      
+        function selectCategory(category: string) {
+          setSelectedCategory(category);
+          setFilterOpen(false);
+        }
+      
+        return (
+          <>
+            <SearchFilter onClick={toggleFilter}>
+              <FilterLogo width={12} height={12} style={{ marginRight: 5 }} />
+              {selectedCategory || "상세 필터"}
+            </SearchFilter>
+            {filterOpen && (
+              <Dropdown>
+                {categories.map((category) => (
+                  <DropdownItem key={category} onClick={() => selectCategory(category)}>
+                    {category}
+                  </DropdownItem>
+                ))}
+              </Dropdown>
+            )}
+          </>
+        );
+      }
+      
+      export default SideBarSearchFilter;

--- a/src/pages/club/ClubList.tsx
+++ b/src/pages/club/ClubList.tsx
@@ -5,6 +5,7 @@ import { ClubType } from "@/types/clubType";
 import { useGetClubs } from "@/hooks/queries/clubs.query";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import SideBarSearch from "@/layouts/sidebar/components/SideBarSearch";
 
 const ITEMS_PER_PAGE = 9;
 
@@ -34,11 +35,21 @@ function ClubList() {
   const { data } = useGetClubs();
   const clubs = data.data.clubs;
   const pagination = data.data.pagination;
-
-  const [currentPage, setCurrentPage] = useState<number>(1);
   const navigate = useNavigate();
+
+  const [searchText, setSearchText] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState("");
+  const [currentPage, setCurrentPage] = useState<number>(1);
+
   const startIdx = (currentPage - 1) * ITEMS_PER_PAGE;
-  const sliceClub = clubs.slice(startIdx, startIdx + ITEMS_PER_PAGE);
+
+  const filteredClubs = clubs.filter(
+    (club) =>
+      club.name.includes(searchText) &&
+      (selectedCategory ? club.category === selectedCategory : true)
+  );
+
+  const sliceClub = filteredClubs.slice(startIdx, startIdx + ITEMS_PER_PAGE);
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
@@ -55,10 +66,11 @@ function ClubList() {
           <ClubBox key={club.id} club={club} onClick={() => onClick(club)} />
         ))}
       </ClubGrid>
+
       <PaginateSection>
         {pagination && (
           <Pagination
-            clubsLength={clubs.length}
+            clubsLength={filteredClubs.length}
             ITEMS_PER_PAGE={ITEMS_PER_PAGE}
             currentPage={currentPage}
             onPageChange={handlePageChange}


### PR DESCRIPTION
## #️⃣연관된 이슈

사이드바 검색과 상세필터 수정

## 📝작업 내용

사이드바 검색과 상세필터 드롭다운으로 나타나게 표시 및 메인 컨테이너에 필터링해서 보이게 적용

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/4ab830df-659c-40c0-8e79-7e374f404b9c)


## 💬리뷰 요구사항(선택)
API가 제대로 연결돼야 테스트해볼 수 있을 듯 합니다 
지금 더미데이터가 카테고리랑 맞지않아 적용이 안되는듯해욥