### PR TITLE
Feat: 토큰에 따른 라우터 조건 분기 및 기능

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,8 +14,8 @@ import Login from "./pages/Login";
 import UserInfo from "./pages/UserInfo";
 import Favorite from "./pages/favorite/Favorite";
 import { useAuthStore } from "./stores/useAuthStore";
-import SystemMaintenance from "./pages/SystemMaintenance"; 
-
+import SystemMaintenance from "./pages/SystemMaintenance";
+import { Loader as FavoriteLoader } from "./pages/favorite/Favorite";
 const router = createBrowserRouter([
   {
     path: "/",
@@ -41,14 +41,15 @@ const router = createBrowserRouter([
       {
         path: "favorite",
         element: <Favorite />,
+        loader: FavoriteLoader,
       },
       {
         path: "loading",
         element: <Loading />,
       },
-      { 
-        path: "maintenance", 
-        element: <SystemMaintenance /> 
+      {
+        path: "maintenance",
+        element: <SystemMaintenance />,
       },
     ],
   },

--- a/src/components/FavoriteButton.tsx
+++ b/src/components/FavoriteButton.tsx
@@ -6,6 +6,9 @@ import { ClubType } from "@/types/clubType";
 import styled from "styled-components";
 import StarLogo from "@/assets/starLogo.svg?react";
 import StarEmptyLogo from "@/assets/starEmptyLogo.svg?react";
+import {
+  isLoginChecking,
+} from "@/stores/useAuthStore";
 
 const FavoriteButtonContainer = styled.button`
   background: transparent;
@@ -26,6 +29,10 @@ function FavoriteButton({ club }: FavoriteButtonProps) {
 
   const handleFavoriteClick = (e: React.MouseEvent) => {
     e.stopPropagation();
+    if (isLoginChecking()) {
+      alert("로그인을 해야 이용할 수 있습니다!");
+      return;
+    }
     if (club.favorite) {
       favoriteDelete(String(club.id));
     } else {

--- a/src/pages/favorite/Favorite.tsx
+++ b/src/pages/favorite/Favorite.tsx
@@ -1,6 +1,8 @@
 import styled from "styled-components";
 import CalendarComponent from "./Calendar";
 import FavoriteClubList from "./FavoriteClubList";
+import { isLoginChecking } from "@/stores/useAuthStore";
+import { redirect } from "react-router-dom";
 
 const FavoritePageWrapper = styled.div`
   display: flex;
@@ -33,6 +35,13 @@ const Favorite = () => {
       </SectionWrapper>
     </FavoritePageWrapper>
   );
+};
+
+export const Loader = () => {
+  if (isLoginChecking()) {
+    throw redirect("/");
+  }
+  return null;
 };
 
 export default Favorite;

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -43,3 +43,7 @@ export const isTokenExpired = (): boolean => {
   const { expiresAt } = useAuthStore.getState();
   return !expiresAt || Date.now() > expiresAt;
 };
+
+export const isLoginChecking = (): boolean => {
+  return isTokenExpired() || useAuthStore.getState().accessToken === null;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

Feat: 토큰에 따른 라우터 조건 분기 및 기능

## 📝작업 내용

1. 로그인을 해야 즐겨찾기 페이지에 들어갈 수 있습니다.
2. 즐겨찾기 버튼을 로그인안하고 누를 시 경고창이 뜨고 작동이 되지 않습니다.

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/0abe2bbf-bb5b-42a4-80fb-f21f10f61bf7)


## 💬리뷰 요구사항(선택)

즐겨찾기 버튼을 누르면 아무런 문구 없이 home으로 이동하기 때문에 별로다 싶으면 의견 주시면 됩니다.
loader방식으로 라우터를 보호해서 잘못된 접근 시 즉시 리다이렉트 (깜빡임 없음) 됩니다. 
컴포넌트 기반 보호가 더 나을 것 같다하면 의견 주세요
