### PR TITLE
Fix: 메인 카테고리 필터링 기능 및 새로고침시 필터링 유지

### DIFF
--- a/src/pages/club/ClubList.tsx
+++ b/src/pages/club/ClubList.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import Pagination from "../../components/Pagination";
 import { ClubType } from "@/types/clubType";
 import { useGetClubs } from "@/hooks/queries/clubs.query";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useFilterStore } from "@/stores/useFilterStore";
 import { usePrefetchClubs } from "@/hooks/usePrefetchClubs";
@@ -34,7 +34,7 @@ const PaginateSection = styled.div`
 function ClubList() {
   const [currentPage, setCurrentPage] = useState<number>(1);
   const navigate = useNavigate();
-  const { selectedCategory, searchText } = useFilterStore();
+  const { selectedCategory, setSelectedCategory ,searchText } = useFilterStore();
 
   const { data } = useGetClubs(
     currentPage,
@@ -51,6 +51,11 @@ function ClubList() {
     searchText,
     selectedCategory
   );
+
+  useEffect(() => {
+    return () => {
+    };
+  }, []); //메인화면에서 카데고리 선택시 해당 동아리 리스트만 보여주기 위함함
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -9,6 +9,9 @@ import Volunteer from "@/assets/category/Volunteer.svg";
 import styled from "styled-components";
 import { useRef } from "react";
 import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+import { useFilterStore } from "@/stores/useFilterStore";
+import { ClubCategory } from "@/types/clubType";
 
 const HomeContainer = styled.div`
   justify-content: center;
@@ -136,15 +139,19 @@ const ScrollButton = styled.button`
 `;
 
 function Home() {
+  const navigate = useNavigate();
+  const { setSelectedCategory } = useFilterStore();
+
   const categories = [
-    { name: "학술/교양", img: Academic },
-    { name: "문화/예술", img: Cultural },
-    { name: "봉사/사회", img: Volunteer },
-    { name: "체육", img: Sports },
-    { name: "종교", img: Religious },
-    { name: "친목", img: Group },
-    { name: "기타", img: Other }
+    { name: "학술/교양", img: Academic, filter: ClubCategory.ACADEMIC_CULTURAL },
+    { name: "문화/예술", img: Cultural, filter: ClubCategory.CULTURAL_ART },
+    { name: "봉사/사회", img: Volunteer, filter: ClubCategory.VOLUNTEER_SOCIAL },
+    { name: "체육", img: Sports, filter: ClubCategory.SPORTS },
+    { name: "종교", img: Religious, filter: ClubCategory.RELIGIOUS },
+    { name: "친목", img: Group, filter: ClubCategory.SOCIAL },
+    { name: "기타", img: Other, filter: ClubCategory.OTHER },
   ];
+  
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const scroll = (direction: "left" | "right") => {
@@ -152,6 +159,12 @@ function Home() {
       const scrollAmount = direction === "left" ? -425 : 425; // 한 버튼 크기만큼 스크롤
       scrollRef.current.scrollBy({ left: scrollAmount, behavior: "smooth" });
     }
+  };
+
+  const handleCategoryClick = (category: ClubCategory) => {
+    console.log("카테고리 선택됨:", category); // 디버깅용 콘솔 로그 추가
+    setSelectedCategory(category);
+    navigate("/clubs");
   };
 
   return (
@@ -171,11 +184,14 @@ function Home() {
         <ScrollButton onClick={() => scroll("left")}>{"<"}</ScrollButton>
         <CategorySection ref={scrollRef}>
         {categories.map((category) => (
-            <CategoryButton key={category.name}>
-              <CategoryImage src={category.img} alt={category.name} />
-              {category.name}
-            </CategoryButton>
-          ))}
+          <CategoryButton
+            key={category.name}
+            onClick={() => handleCategoryClick(category.filter)}
+          >
+            <CategoryImage src={category.img} alt={category.name} />
+            {category.name}
+          </CategoryButton>
+        ))}
         </CategorySection>
         <ScrollButton onClick={() => scroll("right")}>{">"}</ScrollButton>
       </CategoryWrapper>

--- a/src/stores/useFilterStore.ts
+++ b/src/stores/useFilterStore.ts
@@ -1,18 +1,27 @@
 import { create } from "zustand";
 import { ClubCategory } from "@/types/clubType";
+import { persist, createJSONStorage } from "zustand/middleware"; 
 
 type FilterStore = {
   selectedCategory?: ClubCategory; //카테고리
   categories: ClubCategory[];
-  setSelectedCategory: (category: ClubCategory) => void;
+  setSelectedCategory: (category?: ClubCategory) => void;
   searchText: string; //검색어
   setSearchText: (text: string) => void;
 };
 
-export const useFilterStore = create<FilterStore>((set) => ({
-  selectedCategory: undefined,
-  categories: Object.values(ClubCategory),
-  setSelectedCategory: (category) => set({ selectedCategory: category }),
-  searchText: "",
-  setSearchText: (text) => set({ searchText: text }),
-}));
+export const useFilterStore = create<FilterStore>()(
+  persist(
+    (set) => ({
+      selectedCategory: undefined,
+      categories: Object.values(ClubCategory),
+      setSelectedCategory: (category) => set({ selectedCategory: category }),
+      searchText: "",
+      setSearchText: (text) => set({ searchText: text }),
+    }),
+    {
+      name: "filter-storage",  //새로고침해도 카테고리 필터링 유지지
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+);


### PR DESCRIPTION
## #️⃣연관된 이슈

Fix: 메인 카테고리 필터링 기능 및 새로고침시 필터링 유지

## 📝작업 내용

- 메인에서 카테고리 필터링 기능 추가
- 새로고침 시 카테고리 필터링 기능 유지

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
import { persist, createJSONStorage } from "zustand/middleware"; 
새로고침할 때 유지되는거 이거 사용했는데 더 좋은 방법있음 알려주세여