### PR TITLE
Feat: 소속별 페이지 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,6 @@ import ClubList from "./pages/club/ClubList";
 import ClubDetail from "./pages/club/ClubDetail";
 import Recruitment from "./pages/recruitment/Recruitment";
 import Login from "./pages/Login";
-import UserInfo from "./pages/UserInfo";
 import Favorite from "./pages/favorite/Favorite";
 import { useAuthStore } from "./stores/useAuthStore";
 import SystemMaintenance from "./pages/SystemMaintenance";
@@ -28,6 +27,10 @@ const router = createBrowserRouter([
       },
       {
         path: "clubs",
+        element: <ClubList />,
+      },
+      {
+        path: "clubs/:affiliation",
         element: <ClubList />,
       },
       {

--- a/src/layouts/sidebar/components/SideBarContentList.tsx
+++ b/src/layouts/sidebar/components/SideBarContentList.tsx
@@ -36,7 +36,7 @@ function SideBarContentList() {
   const { setSelectedCategory } = useFilterStore();
   return (
     <>
-      <SectionTitle to="/clubs" onClick={() => setSelectedCategory(null)}>
+      <SectionTitle to="/clubs" onClick={() => setSelectedCategory(undefined)}>
         동아리
       </SectionTitle>
       {clubItems.map((item) => (

--- a/src/layouts/sidebar/const/pathLinks.ts
+++ b/src/layouts/sidebar/const/pathLinks.ts
@@ -1,6 +1,6 @@
 export const clubItems = [
-  { name: "중앙 동아리", path: "/club/central" },
-  { name: "가인준 동아리", path: "/club/ga-injun" },
+  { name: "중앙 동아리", path: "/clubs/CENTRAL_CLUB" },
+  { name: "가인준 동아리", path: "/clubs/DEPARTMENT_CLUB" },
 ];
 
 export const recruitItems = [

--- a/src/pages/club/ClubList.tsx
+++ b/src/pages/club/ClubList.tsx
@@ -4,7 +4,7 @@ import Pagination from "../../components/Pagination";
 import { ClubType } from "@/types/clubType";
 import { useGetClubs } from "@/hooks/queries/clubs.query";
 import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useFilterStore } from "@/stores/useFilterStore";
 import { usePrefetchClubs } from "@/hooks/usePrefetchClubs";
 
@@ -33,6 +33,7 @@ const PaginateSection = styled.div`
 
 function ClubList() {
   const [currentPage, setCurrentPage] = useState<number>(1);
+  const { affiliation } = useParams<{ affiliation: string }>();
   const navigate = useNavigate();
   const { selectedCategory, setSelectedCategory ,searchText } = useFilterStore();
 
@@ -40,7 +41,8 @@ function ClubList() {
     currentPage,
     ITEMS_PER_PAGE,
     searchText,
-    selectedCategory
+    selectedCategory,
+    affiliation
   );
   const { clubs, pagination } = data.data;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

Feat: 소속별 페이지 추가

## 📝작업 내용

- 소속별 페이지 추가

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/cbd2fabd-109d-4e60-b6e3-7669910c2313)


## 💬리뷰 요구사항(선택)

따로 페이지 안만들고 사이드바 클릭시 파라미터로 CENTRAL_CLUB 혹은 DEPARTMENT_CLUB 전달하게 했어요.