### PR TITLE
Fix: 소속별 페이지 라우터 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { useAuthStore } from "./stores/useAuthStore";
 import SystemMaintenance from "./pages/SystemMaintenance";
 import { ProtectedRoute } from "./pages/favorite/Favorite";
 import QueryErrorBoundary from "./services/QueryErrorBoundary";
+import UserInfo from "./pages/UserInfo";
 const router = createBrowserRouter([
   {
     path: "/",
@@ -31,7 +32,7 @@ const router = createBrowserRouter([
         element: <ClubList />,
       },
       {
-        path: "clubs/:affiliation",
+        path: "clubs/group/:affiliation",
         element: <ClubList />,
       },
       {

--- a/src/hooks/queries/clubs.query.ts
+++ b/src/hooks/queries/clubs.query.ts
@@ -54,6 +54,7 @@ export const prefetchGetClubs = async (
 };
 
 export const useGetClubsDetail = (id: string) => {
+  console.log(id);
   return useSuspenseQuery<ClubDetailResponseType>({
     queryKey: ["clubs", id],
     queryFn: () => getClubItemsDetail(id),

--- a/src/layouts/sidebar/const/pathLinks.ts
+++ b/src/layouts/sidebar/const/pathLinks.ts
@@ -1,6 +1,6 @@
 export const clubItems = [
-  { name: "중앙 동아리", path: "/clubs/CENTRAL_CLUB" },
-  { name: "가인준 동아리", path: "/clubs/DEPARTMENT_CLUB" },
+  { name: "중앙 동아리", path: "/clubs/group/CENTRAL_CLUB" },
+  { name: "가인준 동아리", path: "/clubs/group/DEPARTMENT_CLUB" },
 ];
 
 export const recruitItems = [

--- a/src/pages/club/ClubList.tsx
+++ b/src/pages/club/ClubList.tsx
@@ -44,7 +44,7 @@ function ClubList() {
     selectedCategory,
     affiliation
   );
-  const { clubs, pagination } = data.data;
+  const { clubs, pagination } = data?.data;
 
   usePrefetchClubs(
     currentPage,
@@ -63,7 +63,7 @@ function ClubList() {
     setCurrentPage(page);
   };
   function onClick(club: ClubType) {
-    navigate(`${club.id}`);
+    navigate(`/clubs/${club.id}`);
   }
 
   return (


### PR DESCRIPTION
## #️⃣연관된 이슈

Fix: 소속별 페이지 라우터 수정

## 📝작업 내용

소속별 페이지 라우터 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

소속별 페이지는 /clubs/group/:affiliation 으로 경로 변경됐어요.
소속별 페이지에서 상세로 접근해야하는 상황 때문에, clublist에서 상세 접근 경로도 수정했습니다.