### PR TITLE
Feat: 즐겨찾기 api 연결/로그아웃 실패

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query": "^5.66.0",
     "@tanstack/react-query-devtools": "^5.66.8",
     "axios": "^1.7.9",
+    "jwt-decode": "^4.0.0",
     "motion": "^12.4.2",
     "msw": "^2.7.3",
     "react": "^19.0.0",

--- a/src/api/favorites.api.ts
+++ b/src/api/favorites.api.ts
@@ -12,5 +12,7 @@ export const deleteFavorite = async (id: string) => {
 
 export const getFavorite = async () => {
   const { data } = await api.get("/favorites");
+
+  console.log("favoriteData:", data);
   return data;
 };

--- a/src/hooks/queries/favorites.query.ts
+++ b/src/hooks/queries/favorites.query.ts
@@ -4,12 +4,14 @@ import {
   updateFavorite,
 } from "@/api/favorites.api";
 import { useOptimisticMutation } from "../useOptimisticMutation";
-import { ClubDetailType, ClubResponseType } from "@/types/clubType";
+import { ClubDetailType } from "@/types/clubType";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { FavoriteResponseType } from "@/types/favoriteType";
 
 export const useFavoriteUpdate = () => {
   return useOptimisticMutation<ClubDetailType, string>(
     ["clubs"],
+    ["favorites"],
     (id) => updateFavorite(id),
     (oldData) => ({
       ...oldData,
@@ -21,6 +23,7 @@ export const useFavoriteUpdate = () => {
 export const useFavoriteDelete = () => {
   return useOptimisticMutation<ClubDetailType, string>(
     ["clubs"],
+    ["favorites"],
     (id) => deleteFavorite(id),
     (oldData) => ({
       ...oldData,
@@ -30,7 +33,7 @@ export const useFavoriteDelete = () => {
 };
 
 export const useGetFavorite = () => {
-  return useSuspenseQuery<ClubResponseType>({
+  return useSuspenseQuery<FavoriteResponseType>({
     queryKey: ["favorites"],
     queryFn: getFavorite,
   });

--- a/src/hooks/useOptimisticMutation.ts
+++ b/src/hooks/useOptimisticMutation.ts
@@ -8,6 +8,7 @@ import { useMutation, useQueryClient, QueryKey } from "@tanstack/react-query";
  */
 export const useOptimisticMutation = <TData, TVariables = void>(
   queryKey: QueryKey,
+  queryKey2: QueryKey,
   mutationFn: (variables: TVariables) => Promise<TData>,
   updater: (oldData: TData, variables?: TVariables) => TData
 ) => {
@@ -44,6 +45,7 @@ export const useOptimisticMutation = <TData, TVariables = void>(
         alert("✅ 성공 - 캐시 동기화");
       }
       queryClient.invalidateQueries({ queryKey });
+      queryClient.invalidateQueries({ queryKey: queryKey2 });
     },
   });
 };

--- a/src/pages/favorite/FavoriteClubList.tsx
+++ b/src/pages/favorite/FavoriteClubList.tsx
@@ -54,7 +54,7 @@ const ClubRecruitPeriod = styled.p`
 
 function FavoriteClubList() {
   const { data } = useGetFavorite();
-  const favoriteClubs = data.data.clubs.filter((club) => club.isFavorite);
+  const favoriteClubs = data.data.filter((club) => club.isFavorite);
   const navigate = useNavigate();
 
   const onClick = (id: number) => {

--- a/src/types/favoriteType.ts
+++ b/src/types/favoriteType.ts
@@ -1,0 +1,5 @@
+import { ClubType } from "./clubType";
+
+export interface FavoriteResponseType {
+  data: ClubType[];
+}

--- a/src/utils/getTokenExpiration.ts
+++ b/src/utils/getTokenExpiration.ts
@@ -1,0 +1,8 @@
+import { jwtDecode } from "jwt-decode";
+
+export function getTokenExpiration(token: string) {
+  const decoded = jwtDecode(token);
+  return decoded.exp
+    ? Math.floor((decoded.exp - Date.now() / 1000) / 60)
+    : null;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2701,6 +2701,11 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jwt-decode@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
+  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
+
 keyv@^4.5.4:
   version "4.5.4"
   resolved "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz"


### PR DESCRIPTION
## #️⃣연관된 이슈

Feat: 즐겨찾기 api 연결/로그아웃 실패

## 📝작업 내용

1. 쿼리키 추가로 즐겨찾기 삭제, 추가 시 get요청에서 즐겨찾기 즉시 반영
2. 로그인 만료시간 가져오기 기능 추가


### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/1f92d665-b410-4fe3-a40d-7b748b95590f)


## 💬리뷰 요구사항(선택)

로그아웃 추후 작업 필요
리프레시 토큰 추후 작업 필요

invalidateQuery할때 전체 club요청을 비활성화해서 모든 데이터를 가져오는 거는 비효율적인 것 같은데
특정 키 즉 그 페이지를 무효화하는 작업 필요