### PR TITLE
Feat: 사이드바 폴딩 기능 추가 & 각 페이지 반응형 CSS (모바일 환경)

### DIFF
--- a/src/components/ModalSection.tsx
+++ b/src/components/ModalSection.tsx
@@ -27,6 +27,10 @@ const ModalContainer = styled.div`
   border-radius: 10px;
   align-items: center;
   justify-content: center;
+  
+  @media (max-width: 770px) {
+    width: 70%;
+  }
 `;
 
 const CloseButton = styled.button`

--- a/src/layouts/components/Header.tsx
+++ b/src/layouts/components/Header.tsx
@@ -14,6 +14,11 @@ const HeaderContainer = styled.div`
   padding: 5px 10px 5px;
   box-sizing: border-box;
   border-bottom: 1px solid #e5e7eb;
+
+  @media (max-width: 770px) {
+    position: fixed;
+    z-index: 3;
+  }
 `;
 
 const HeaderContents = styled.div`

--- a/src/layouts/sidebar/SideBar.tsx
+++ b/src/layouts/sidebar/SideBar.tsx
@@ -1,22 +1,62 @@
 import styled from "styled-components";
 import SideBarSearch from "./components/SideBarSearch";
 import SideBarContentList from "./components/SideBarContentList";
+import { useState } from "react";
 
-const SideBarContainer = styled.div`
+const SideBarContainer = styled.div<{ isOpen: boolean }>`
   padding: 1%;
   width: 22%;
   background-color: #f9fafb;
   display: flex;
   align-items: center;
   flex-direction: column;
+
+  @media (max-width: 770px) {
+    position: fixed;
+    z-index: 9999;
+    min-width: fit-content;
+    width: 40%;
+    height: calc(100% - 60px);
+    margin-top: 60px;
+    transform: ${({ isOpen }) => (isOpen ? "translateX(0)" : "translateX(-100%)")};
+  }
+`;
+
+const ToggleButton = styled.button<{ isOpen: boolean }>`
+  position: fixed;
+  top: 50%;
+  left: ${({ isOpen }) => (isOpen ? "40%" : "0%")};
+  z-index: 9999;
+  background: none;
+  border: none;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transform: translateY(-50%);
+  padding: 10px 5px 10px 10px;
+  box-sizing: border-box;
+  background-color: #f9fafb;
+  border-top-right-radius: 10px;
+  border-bottom-right-radius: 10px;
+
+  @media (min-width: 771px) {
+    display: none;
+  }
 `;
 
 function SideBar() {
+  const [isOpen, setIsOpen] = useState(false);
+
   return (
-    <SideBarContainer>
-      <SideBarSearch />
-      <SideBarContentList />
-    </SideBarContainer>
+    <>
+      <ToggleButton onClick={() => setIsOpen(!isOpen)} isOpen={isOpen}>
+        {isOpen ? "<" : ">"}
+      </ToggleButton>
+      <SideBarContainer isOpen={isOpen}>
+        <SideBarSearch />
+        <SideBarContentList />
+      </SideBarContainer>
+    </>
   );
 }
 

--- a/src/pages/club/ClubList.tsx
+++ b/src/pages/club/ClubList.tsx
@@ -8,19 +8,24 @@ import { useFilterStore } from "@/stores/useFilterStore";
 import { usePrefetchClubs } from "@/hooks/usePrefetchClubs";
 import NoResults from "@/pages/NoResults";
 
-const ITEMS_PER_PAGE = 9;
+const ITEMS_PER_PAGE = 12;
+
+const ClubWrapper = styled.div`
+  @media (max-width: 770px) {
+    margin-top: 60px;
+  }
+`;
 
 const ClubGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(3, 30%);
-  grid-template-rows: repeat(3, 30%);
   width: 100%;
   height: 80%;
   justify-content: space-evenly;
   align-content: space-evenly;
 
-  @media (max-width: 768px) {
-    grid-template-columns: 1fr;
+  @media (max-width: 770px) {
+    grid-template-columns: repeat(1, 90%);
   }
 `;
 
@@ -66,7 +71,7 @@ function ClubList() {
       {clubs.length === 0 ? (
         <NoResults />
       ) : (
-        <>
+        <ClubWrapper>
           <ClubGrid>
             {clubs.map((club) => (
               <ClubBox key={club.id} club={club} onClick={() => onClick(club)} />
@@ -82,7 +87,7 @@ function ClubList() {
               />
             )}
           </PaginateSection>
-        </>
+        </ClubWrapper>
       )}
     </>
   );

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -62,10 +62,15 @@ const HomeTitle = styled.p`
 `;
 
 const HomeDescription = styled.p`
+  line-height: 1.3;
   font-size: 1.3rem;
   color: white;
   margin-top: -40px;
   text-align: center;
+
+  @media (max-width: 770px) {
+    font-size: 0.9rem;
+  }
 `;
 
 const ExploreButton = styled(Link)`
@@ -203,10 +208,10 @@ function Home() {
         <HomeLogoSection>
           <HomeTitle> <Mokkoji width={180} height={150} /> </HomeTitle>
           <HomeDescription>
-            세종대의 다양한 동아리를 한곳에서 만나보세요. <br/> 
-            관심 있는 동아리를 찾고, 새로운 사람들과 함께하세요! <br/>
+            세종대의 다양한 동아리를 한곳에서 만나보세요. <br />
+            관심 있는 동아리를 찾고, 새로운 사람들과 함께하세요! <br />
             지금 동아리 리스트를 확인해보세요 🔍
-            </HomeDescription>
+          </HomeDescription>
           <ExploreButton to="/clubs"> 동아리 찾아보기</ExploreButton>
         </HomeLogoSection>
       </HomeContainer>

--- a/src/pages/recruitment/Recruitment.tsx
+++ b/src/pages/recruitment/Recruitment.tsx
@@ -10,22 +10,30 @@ import { useNavigate } from "react-router-dom";
 import { useFilterStore } from "@/stores/useFilterStore"; 
 import NoResults from "@/pages/NoResults";
 
-const ITEMS_PER_PAGE = 9; // 페이지당 게시물 수
+const ITEMS_PER_PAGE = 12; // 페이지당 게시물 수
 
 const Container = styled.div`
-  width: 78vw;
-  height: 100%;
+  width: 100%;
+  height: fit-content;
   position: relative;
+
+  @media (max-width: 770px) {
+    margin-top: 60px;
+  }
 `;
 
 const ClubList = styled.div`
   display: grid;
   grid-template-columns: repeat(3, 32%);
-  grid-template-rows: repeat(3, 30%);
   width: 100%;
-  height: 80%;
+  height: fit-content;
   justify-content: space-evenly;
   align-content: space-evenly;
+  margin-bottom: 2%;
+
+  @media (max-width: 770px) {
+    grid-template-columns: repeat(2, 48%);
+  }
 `;
 
 const ClubCardWrapper = styled.div`
@@ -35,6 +43,7 @@ const ClubCardWrapper = styled.div`
   border-radius: 10px;
   background-color: white;
   cursor: pointer;
+  margin: 5px 0;
 `;
 
 function Recruitment() {
@@ -76,7 +85,8 @@ function Recruitment() {
 
   return (
     <Container>
-      <SortOption buttonState={buttonState} onSortChange={handleSortChange} />
+      {/* 기능추가 전까지 주석처리 */}
+      {/*<SortOption buttonState={buttonState} onSortChange={handleSortChange} />*/}
 
       {sortedClubs.length === 0 ? (
         <NoResults />


### PR DESCRIPTION
## #️⃣연관된 이슈

Feat: 사이드바 폴딩 기능 추가 & 각 페이지 반응형 CSS (모바일 환경)

## 📝작업 내용

- 사이드바 폴딩 기능 추가
- 각 페이지 (전체 동아리/모집 공고/로그인 모달/메인 페이지) 모바일 반응형 CSS

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/c69569fc-2ce2-42ab-9669-7fc93d1e52bc)
![image](https://github.com/user-attachments/assets/95bf54e9-03c0-4391-af78-1261558ea31f)
![image](https://github.com/user-attachments/assets/ed5fe584-f873-46e8-b9ea-ca997465b718)
![image](https://github.com/user-attachments/assets/7429fe91-4d6a-42ad-8e9e-76abf94407ec)
![image](https://github.com/user-attachments/assets/e9edb9d6-f51c-4e6a-9323-a844590ee89e)


## 💬리뷰 요구사항(선택)

아무래도 에타 홍보가 주라면 대부분의 이용자는 모바일일게 뻔해서 최대한 맞춰보았습니다.
너비가 부족하기 때문에 사이드바는 폴딩 기능으로 빼버렸습니다.
데스크톱 환경은 3의 배수, 모바일은 2의 배수로 아이템이 보여지다보니, ITEMS_PER_PAGE를 12로 수정하였습니다.
좀 더 나은 선택지나 아이디어가 있다면 말씀해주세요!

아, 참고로 모바일 환경과 유사하게 테스트 해보려면 개발자도구(F12)열고 ctrl+shift+m 하면 화면 사이즈 조절됩니다.