### PR TITLE
Feat: 사이드바 홈 버튼&사이드바와 페이지네이션 UX수정

### DIFF
--- a/src/layouts/sidebar/SideBar.tsx
+++ b/src/layouts/sidebar/SideBar.tsx
@@ -55,7 +55,7 @@ function SideBar() {
       </ToggleButton>
       <SideBarContainer $isOpen={isOpen}>
         <SideBarSearch />
-        <SideBarContentList />
+        <SideBarContentList setIsOpen={setIsOpen} />
       </SideBarContainer>
     </>
   );

--- a/src/layouts/sidebar/components/SideBarContentList.tsx
+++ b/src/layouts/sidebar/components/SideBarContentList.tsx
@@ -3,7 +3,6 @@ import styled from "styled-components";
 import { clubItems } from "../const/pathLinks";
 import Spacing from "@/components/Spacing";
 import { useFilterStore } from "@/stores/useFilterStore";
-import { useState } from "react"
 
 const SectionTitle = styled(Link)<{ $active: boolean }>`
   width: 90%;
@@ -44,16 +43,24 @@ const SectionLink = styled(Link)<{ $active: boolean }>`
 `;
 
 function SideBarContentList() {
-  const { resetAll } = useFilterStore();
-  const [selectedMenu, setSelectedMenu] = useState<string>("");
+  const { resetAll, selectedMenu, setSelectedMenu } = useFilterStore();
 
   function handleMenuClick(menu: string) {
+    console.log("선택한 메뉴:", menu); // 디버깅용
     setSelectedMenu(menu);
     resetAll();
+    console.log("업데이트된 메뉴:", selectedMenu); // 업데이트 확인
   }
 
   return (
     <>
+      <SectionTitle
+        to="/"
+        onClick={() => handleMenuClick("HOME")}
+        $active={selectedMenu === "HOME"}
+      >
+        HOME
+      </SectionTitle>
       <SectionTitle
         to="/clubs"
         onClick={() => handleMenuClick("전체 동아리")}

--- a/src/layouts/sidebar/components/SideBarContentList.tsx
+++ b/src/layouts/sidebar/components/SideBarContentList.tsx
@@ -42,14 +42,16 @@ const SectionLink = styled(Link)<{ $active: boolean }>`
   }
 `;
 
-function SideBarContentList() {
+function SideBarContentList({ setIsOpen }: { setIsOpen: (isOpen: boolean) => void }) {
   const { resetAll, selectedMenu, setSelectedMenu } = useFilterStore();
 
   function handleMenuClick(menu: string) {
-    console.log("선택한 메뉴:", menu); // 디버깅용
     setSelectedMenu(menu);
     resetAll();
-    console.log("업데이트된 메뉴:", selectedMenu); // 업데이트 확인
+
+    if(window.innerWidth <= 770){
+      setIsOpen(false);
+    }
   }
 
   return (

--- a/src/pages/club/ClubList.tsx
+++ b/src/pages/club/ClubList.tsx
@@ -66,6 +66,7 @@ function ClubList() {
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
+    window.scrollTo(0, 0);
   };
   function onClick(club: ClubType) {
     navigate(`/clubs/${club.id}`);

--- a/src/pages/recruitment/Recruitment.tsx
+++ b/src/pages/recruitment/Recruitment.tsx
@@ -58,8 +58,8 @@ function Recruitment() {
     searchText,
     selectedCategory
   );
-  const { clubs, pagination } = data.data;
 
+  const { clubs, pagination } = data.data;
 
   useEffect(() => {
     if (clubs.length > 0) {
@@ -84,6 +84,7 @@ function Recruitment() {
   // 현재 페이지 번호 상태 변경
   function handlePageChange(page: number) {
     setCurrentPage(page);
+    window.scrollTo(0, 0);
   }
 
   function onClick(club: ClubType) {

--- a/src/stores/useFilterStore.ts
+++ b/src/stores/useFilterStore.ts
@@ -52,7 +52,6 @@ export const useFilterStore = create<FilterStore>()(
           selectedCategory: undefined,
           searchText: "",
           currentPage: 1,
-          selectedMenu: state.selectedMenu,
         })),
     }),
     {

--- a/src/stores/useFilterStore.ts
+++ b/src/stores/useFilterStore.ts
@@ -33,7 +33,7 @@ export const useFilterStore = create<FilterStore>()(
 
       setCurrentPage: (page) => set(() => ({ currentPage: page })),
 
-      selectedMenu: "", // 초기 메뉴 값
+      selectedMenu: "HOME", // 초기 메뉴 값
       setSelectedMenu: (menu) => set(() => ({ selectedMenu: menu })),
 
    
@@ -45,14 +45,14 @@ export const useFilterStore = create<FilterStore>()(
         })),
         
   
-      resetMenu: () => set(() => ({ selectedMenu: "" })),
+      resetMenu: () => set(() => ({ selectedMenu: "HOME" })),
 
       resetAll: () => 
         set(() => ({
           selectedCategory: undefined,
           searchText: "",
           currentPage: 1,
-          selectedMenu: "",
+          selectedMenu: state.selectedMenu,
         })),
     }),
     {


### PR DESCRIPTION
## #️⃣연관된 이슈

Feat: 사이드바 홈 버튼&사이드바와 페이지네이션 UX수정

## 📝작업 내용

- [x] 홈 메뉴 버튼 추가
- [x] 페이지네이션 변경시 최상단으로 화면 이동
- [x] 홈 버튼 눌렀을때 메뉴 액티브 해제
- [x] 메뉴 선택시 사이드바 폴딩(모바일)

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/44ebcdfb-e270-4274-be3d-6c77547c1aab)

## 💬리뷰 요구사항(선택)

사이드바의 홈메뉴 워딩은 변경해도 됩니다.
useFilterStore.ts에 있는 resetAll() 의 selectedMenu는 의도치 않은 동작을 하는것 같아서 제거했는데, 문제가 된다면 알려주세요.
사이드바 버튼 동작(+모바일도)에 불편함이 느껴진다면 의견주세요.