### PR TITLE
Fix: 카테고리 친목 생성, 기타 제거

### DIFF
--- a/src/components/utils/clubCategoryMapping.ts
+++ b/src/components/utils/clubCategoryMapping.ts
@@ -6,6 +6,6 @@ export const ClubCategoryKorean: Record<ClubCategory, string> = {
   [ClubCategory.VOLUNTEER_SOCIAL]: "봉사/사회",
   [ClubCategory.SPORTS]: "체육",
   [ClubCategory.RELIGIOUS]: "종교",
-  [ClubCategory.OTHER]: "기타",
+  [ClubCategory.SOCIAL]: " 친목",
   [ClubCategory.ALL]: "전체",
 };

--- a/src/pages/home/const/categories.ts
+++ b/src/pages/home/const/categories.ts
@@ -4,6 +4,7 @@ import Other from "@/assets/category/Other.svg";
 import Religious from "@/assets/category/Religious.svg";
 import Sports from "@/assets/category/Sports.svg";
 import Volunteer from "@/assets/category/Volunteer.svg";
+import Group from "@/assets/category/Group.svg";
 import { ClubCategory } from "@/types/clubType";
 
 
@@ -19,7 +20,7 @@ export const categories = [
     img: Volunteer,
     filter: ClubCategory.VOLUNTEER_SOCIAL,
   },
+  { name: "친목", img: Group, filter: ClubCategory.SOCIAL },
   { name: "체육", img: Sports, filter: ClubCategory.SPORTS },
   { name: "종교", img: Religious, filter: ClubCategory.RELIGIOUS },
-  { name: "기타", img: Other, filter: ClubCategory.OTHER },
 ];

--- a/src/types/clubType.ts
+++ b/src/types/clubType.ts
@@ -4,7 +4,7 @@ export enum ClubCategory {
   VOLUNTEER_SOCIAL = "VOLUNTEER_SOCIAL",
   SPORTS = "SPORTS",
   RELIGIOUS = "RELIGIOUS",
-  OTHER = "OTHER",
+  SOCIAL = "SOCIAL",
   ALL = "ALL"
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

Fix: 카테고리 친목 생성, 기타 제거

## 📝작업 내용

카테고리: 친목 생성, 기타 제거

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/470c3204-a2a7-4f22-90f7-000929db9c40)

## 💬리뷰 요구사항(선택)

화면과 같이 친목 생성했고 기타 제거했습니다. 
현재 기타 관련한 데이터가 날라와서 아래에 저런 들어갈 수 잇는 공간이 생기는 거 같습니다