### PR TITLE
Feat: 즐겨찾기 페이지 반응형&일부 CSS

### DIFF
--- a/src/pages/favorite/Favorite.tsx
+++ b/src/pages/favorite/Favorite.tsx
@@ -16,6 +16,9 @@ const FavoritePageWrapper = styled.div`
   gap: 1rem;
   margin-top: 1%;
   margin-bottom: 1%;
+  @media (max-width: 770px) {
+    margin-top: 60px;
+  }
 `;
 
 const SectionWrapper = styled.div`

--- a/src/pages/favorite/components/FavoriteClubList.tsx
+++ b/src/pages/favorite/components/FavoriteClubList.tsx
@@ -13,6 +13,11 @@ const ClubGrid = styled.div`
   grid-template-columns: repeat(auto-fit, minmax(28%, 1fr));
   gap: 1rem;
   justify-content: center;
+
+  @media (max-width: 770px) {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(47%, 1fr));
+  }
 `;
 
 function FavoriteClubList() {

--- a/src/pages/favorite/components/calendar/Calendar.tsx
+++ b/src/pages/favorite/components/calendar/Calendar.tsx
@@ -9,16 +9,30 @@ const Title = styled.h2`
   margin-bottom: 1rem;
 `;
 
+const CalendarStyles = styled.div`
+  .react-calendar__tile {
+    display: flex;
+    flex-direction: column;
+    min-height: 100px;
+  }
+  .react-calendar__tile abbr {
+    box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
+    font-weight: bold;
+    display: flex;
+    justify-content: center;
+  }
+`;
+
 function Calendar() {
   return (
-    <>
+    <CalendarStyles>
       <Title>일정</Title>
       <CustomCalendar
         tileContent={({ date }) => {
           return <CalendarItem date={date} />;
         }}
       />
-    </>
+    </CalendarStyles>
   );
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

Feat: 즐겨찾기 페이지 반응형&일부 CSS

## 📝작업 내용

- 즐겨찾기 페이지 반응형&일부 CSS

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/e99bd3ea-e243-4076-9be0-04d9bec897cb)

![image](https://github.com/user-attachments/assets/c69a8453-d66c-4bfa-b77e-eb9b71439317)


## 💬리뷰 요구사항(선택)

모바일 반응형이랑 캘린더는 최소 높이 정도만 건드렸습니다.
요일 중에 토, 일도 색상 변경 가능하니 필요하면 수정하겠습니다.