### PR TITLE
Fix: category=All 경로 필터

### DIFF
--- a/src/api/clubs.api.ts
+++ b/src/api/clubs.api.ts
@@ -1,37 +1,39 @@
-import api from ".";
-import {
-  ClubDetailResponseType,
-  ClubResponseType,
-  ClubCategory,
-} from "@/types/clubType";
+  import api from ".";
+  import {
+    ClubDetailResponseType,
+    ClubResponseType,
+    ClubCategory,
+  } from "@/types/clubType";
 
-export const getClubItems = async (
-  page: number,
-  size: number,
-  keyword?: string,
-  category?: ClubCategory,
-  affiliation?: string,
-  recruitStatus?: string
-): Promise<ClubResponseType> => {
-  const { data } = await api.get(`/clubs`, {
-    params: {
-      keyword,
-      category,
-      affiliation,
-      page,
-      size,
-      recruitStatus,
-    },
-  });
+  export const getClubItems = async (
+    page: number,
+    size: number,
+    keyword?: string,
+    category?: ClubCategory,
+    affiliation?: string,
+    recruitStatus?: string
+  ): Promise<ClubResponseType> => {
+    const params = Object.fromEntries(
+      Object.entries({
+        keyword,
+        category: category !== "ALL" ? category : undefined,
+        affiliation,
+        page,
+        size,
+        recruitStatus,
+      }).filter(([_, value]) => value !== "")
+    );
 
-  return data;
-};
+    const { data } = await api.get(`/clubs`, { params });
 
-export const getClubItemsDetail = async (
-  id: string
-): Promise<ClubDetailResponseType> => {
-  const { data } = await api.get(`/clubs/${id}`);
+    return data;
+  };
+
+  export const getClubItemsDetail = async (
+    id: string
+  ): Promise<ClubDetailResponseType> => {
+    const { data } = await api.get(`/clubs/${id}`);
 
 
-  return data;
-};
+    return data;
+  };

--- a/src/pages/favorite/components/FavoriteClubList.tsx
+++ b/src/pages/favorite/components/FavoriteClubList.tsx
@@ -22,7 +22,6 @@ const ClubGrid = styled.div`
 
 function FavoriteClubList() {
   const { data } = useGetFavorite();
-  console.log(data.data[0].imageURL);
 
   return (
     <>


### PR DESCRIPTION
## #️⃣연관된 이슈

Fix: category=All 경로 필터

## 📝작업 내용

- category=All 경로 필터

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/58d0b17b-67f7-41eb-8a04-7810a6b0cbc2)

## 💬리뷰 요구사항(선택)

상세필터와 메인페이지 카테고리 선택에서 category=All 이런 파라미터가 붙어서 넘어가는데, 도저히 찾을 수가 없어서 api요청단에서 필터하도록 했습니다.
추가로 키워드가 없을때 빈값("")이 넘어가서 자꾸 keyword=& 같은 형태가 되길래 그 역시도 필터하도록 했습니다.
콘솔로그는 필요없을거 같아 제거했습니다.